### PR TITLE
Add class-based typed api view

### DIFF
--- a/rest_typed_views/__init__.py
+++ b/rest_typed_views/__init__.py
@@ -1,4 +1,5 @@
 from .decorators import typed_action, typed_api_view
+from .views import TypedAPIView
 from .param_settings import ParamSettings
 
 

--- a/rest_typed_views/views.py
+++ b/rest_typed_views/views.py
@@ -1,0 +1,42 @@
+import inspect
+
+from rest_framework.views import APIView
+from .decorators import transform_view_params
+
+
+class TypedAPIView(APIView):
+    def dispatch(self, request, *args, **kwargs):
+        """
+        Override drf's `dispatch` for typing params.
+        """
+        self.args = args
+        self.kwargs = kwargs
+        request = self.initialize_request(request, *args, **kwargs)
+        self.request = request
+        self.headers = self.default_response_headers  # deprecate?
+
+        try:
+            self.initial(request, *args, **kwargs)
+
+            # Get the appropriate handler method
+            if request.method.lower() in self.http_method_names:
+                handler = getattr(
+                    self, request.method.lower(), self.http_method_not_allowed
+                )
+            else:
+                handler = self.http_method_not_allowed
+
+            typed_params = [
+                p
+                for n, p in inspect.signature(handler).parameters.items()
+                if n != "self"
+            ]
+            transformed = transform_view_params(typed_params, request, kwargs)
+
+            response = handler(*transformed)
+
+        except Exception as exc:
+            response = self.handle_exception(exc)
+
+        self.response = self.finalize_response(request, response, *args, **kwargs)
+        return self.response

--- a/test_project/testapp/tests/test_typed_api_view_class.py
+++ b/test_project/testapp/tests/test_typed_api_view_class.py
@@ -1,0 +1,66 @@
+from rest_framework.reverse import reverse
+from rest_framework.test import APITestCase
+
+from test_project.testapp.models import Movie
+
+
+class TypedAPIViewClassTests(APITestCase):
+    def test_get_musics_ok(self):
+        url = reverse("music-list")
+        response = self.client.get(url, {"limit": 5}, format="json")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.data, {"data": [], "limit": 5, "offset": 0}
+        )
+
+    def test_get_musics_error(self):
+        url = reverse("music-list")
+        response = self.client.get(url, {"limit": 20}, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(), {
+                "limit": ["Ensure this value is less than or equal to 10."]}
+        )
+
+    def test_create_music_ok(self):
+        url = reverse("music-list")
+        response = self.client.post(
+            url, {
+                "id": 123,
+                "title": "My Music",
+                "rating": 5,
+                "genre": "jazz"
+            }, format="json"
+        )
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(
+            response.data, {
+                "id": 123,
+                "title": "My Music",
+                "rating": 5,
+                "genre": "jazz"
+            }
+        )
+
+    def test_create_music_error(self):
+        url = reverse("music-list")
+        response = self.client.post(
+            url, {
+                "id": 123,
+                "title": "My Music"
+            }, format="json"
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertEqual(
+            response.json(),
+            {
+                "music": [
+                    {
+                        "loc": "('genre',)",
+                        "msg": "field required",
+                        "type": "value_error.missing",
+                    }
+                ]
+            },
+        )

--- a/test_project/testapp/view_class.py
+++ b/test_project/testapp/view_class.py
@@ -1,0 +1,35 @@
+from typing import List
+
+from pydantic import BaseModel
+from rest_framework.response import Response
+
+from rest_typed_views import TypedAPIView, Query, Path
+
+
+class MusicSchema(BaseModel):
+    id: int
+    title: str
+    rating: int = None
+    genre: str
+
+
+class MusicAPIView(TypedAPIView):
+
+    def get(
+        self,
+        limit: int = Query(default=5, min_value=1, max_value=10),
+        offset: int = 0
+    ):
+        return Response(data={
+            "data": [],
+            "limit": limit,
+            "offset": offset
+        }, status=200)
+
+    def post(self, music: MusicSchema):
+        return Response(data={
+            "id": music.id,
+            "title": music.title,
+            "rating": music.rating,
+            "genre": music.genre
+        }, status=201)

--- a/test_project/urls.py
+++ b/test_project/urls.py
@@ -10,6 +10,7 @@ from test_project.testapp.views import (
     test_view,
 )
 from test_project.testapp.view_sets import MovieViewSet
+from test_project.testapp.view_class import MusicAPIView
 
 router = routers.SimpleRouter()
 
@@ -24,4 +25,5 @@ urlpatterns = [
     url(r"^band-members/", create_band_member, name="create-band-member"),
     url(r"^get-cache-header/", get_cache_header, name="get-cache-header"),
     url(r"^", include(router.urls)),
+    url(r"^musics/", MusicAPIView.as_view(), name="music-list")
 ]


### PR DESCRIPTION
I use `APIView` in my Django project a lot, so I created `TypedAPIView` class.
I think this class will broaden the adoption of your library.

I overrided drf's `dispatch` method in `APIView` class. I only modified following part of original `dispatch` method.

```py
typed_params = [
    p
    for n, p in inspect.signature(handler).parameters.items()
    if n != "self"
]
transformed = transform_view_params(typed_params, request, kwargs)

response = handler(*transformed)
```

I use this class in my project, and it is working well. But, I couldn't create appropriate test codes.
Could you(@rsinger86 ) create them? Or, you can give me some guidance for test codes.